### PR TITLE
Allow regex for cors origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Aplicación full-stack para gestión de finanzas personales.
 ```
 MONGO_URI=
 JWT_SECRET=
+# FRONTEND_URL puede ser una URL o varias separadas por comas
 FRONTEND_URL=https://tu-frontend.vercel.app
+# Para comodines se puede usar FRONTEND_URL_REGEX
+# Ejemplo para aceptar cualquier subdominio de Vercel
+# FRONTEND_URL_REGEX=^https://.*\.vercel\.app$
 PORT=5000
 ```
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,11 +6,27 @@ const cors = require("cors");
 const app = express();
 const PORT = process.env.PORT || 5000;
 
-// Configurar CORS usando variable de entorno FRONTEND_URL
+// Configurar CORS usando variable de entorno FRONTEND_URL o FRONTEND_URL_REGEX
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
+const FRONTEND_URL_REGEX = process.env.FRONTEND_URL_REGEX;
+
+let corsOrigin = FRONTEND_URL;
+
+// Si se define FRONTEND_URL_REGEX, usarlo como expresión regular
+if (FRONTEND_URL_REGEX) {
+  try {
+    corsOrigin = new RegExp(FRONTEND_URL_REGEX);
+  } catch (err) {
+    console.error("FRONTEND_URL_REGEX inválido:", err);
+  }
+} else if (FRONTEND_URL.includes(",")) {
+  // Permitir lista de orígenes separados por comas
+  corsOrigin = FRONTEND_URL.split(",").map((url) => url.trim());
+}
+
 app.use(
   cors({
-    origin: FRONTEND_URL,
+    origin: corsOrigin,
   })
 );
 app.use(express.json());


### PR DESCRIPTION
## Summary
- support regex or multiple entries in `FRONTEND_URL`
- document wildcard regex for cors configuration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684971b76b8c8325b63aa4747f9f936b