### PR TITLE
Add global auth context and protected routing

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 // frontend/src/components/Layout.jsx
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Navbar, Nav, Container, Offcanvas, Button } from "react-bootstrap";
 import {
@@ -16,14 +16,17 @@ import {
   FaQuestionCircle,
   FaBookOpen,
 } from "react-icons/fa";
+import { AuthContext } from "../context/AuthContext";
 
-const Layout = ({ children, isAuthenticated, user, onLogout }) => {
+const Layout = ({ children }) => {
+  const { user, token, logout } = useContext(AuthContext);
+  const isAuthenticated = !!token;
   const [showOffcanvas, setShowOffcanvas] = useState(false);
   const history = useHistory();
   const location = useLocation();
 
   const handleLogoutInternal = () => {
-    if (onLogout) onLogout();
+    logout();
     setShowOffcanvas(false);
   };
 

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const ProtectedRoute = ({ component: Component, ...rest }) => {
+  const { token } = useContext(AuthContext);
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        token ? <Component {...props} /> : <Redirect to="/" />
+      }
+    />
+  );
+};
+
+export default ProtectedRoute;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,51 @@
+import React, { createContext, useState, useEffect, useCallback } from 'react';
+import api from '../services/api';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  const [loading, setLoading] = useState(true);
+
+  const fetchUserProfile = useCallback(async () => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await api.get('/auth');
+      setUser(res.data);
+    } catch (err) {
+      console.error('Error fetching user profile:', err.response?.data || err.message);
+      logout();
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchUserProfile();
+  }, [fetchUserProfile]);
+
+  const login = async (email, password) => {
+    const res = await api.post('/auth/login', { email, password });
+    setToken(res.data.token);
+    setUser(res.data.user);
+    localStorage.setItem('token', res.data.token);
+    localStorage.setItem('user', JSON.stringify(res.data.user));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,12 +5,15 @@ import "./index.css"; // Si tienes un archivo CSS global, consérvalo
 import "bootstrap/dist/css/bootstrap.min.css"; // Estilos globales de Bootstrap
 import "react-toastify/dist/ReactToastify.css"; // <-- NUEVA LÍNEA: Estilos de React-Toastify
 import App from "./App";
+import { AuthProvider } from "./context/AuthContext";
 import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/AccountsPage.jsx
+++ b/frontend/src/pages/AccountsPage.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/AccountsPage.jsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
 import {
   Container,
@@ -12,8 +12,10 @@ import {
 } from "react-bootstrap";
 import { FaEdit, FaTrashAlt } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
 
-const AccountsPage = ({ token }) => {
+const AccountsPage = () => {
+  const { token } = useContext(AuthContext);
   const [accounts, setAccounts] = useState([]);
   const [newAccountName, setNewAccountName] = useState("");
   const [newAccountType, setNewAccountType] = useState("Cuenta Bancaria");

--- a/frontend/src/pages/CategoriesPage.jsx
+++ b/frontend/src/pages/CategoriesPage.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/CategoriesPage.jsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
 import {
   Container,
@@ -12,8 +12,10 @@ import {
 } from "react-bootstrap";
 import { FaEdit, FaTrashAlt } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
 
-const CategoriesPage = ({ token }) => {
+const CategoriesPage = () => {
+  const { token } = useContext(AuthContext);
   const [categories, setCategories] = useState([]);
   const [newCategoryName, setNewCategoryName] = useState("");
   const [newCategoryType, setNewCategoryType] = useState("Gasto");

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,10 +1,12 @@
 // frontend/src/pages/DashboardPage.jsx
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import api from '../services/api';
 import { Container, Row, Col, Card, Alert, ListGroup, Image } from 'react-bootstrap';
 import { toast } from 'react-toastify';
+import { AuthContext } from '../context/AuthContext';
 
-const DashboardPage = ({ token }) => {
+const DashboardPage = () => {
+  const { token } = useContext(AuthContext);
   const [totalBalance, setTotalBalance] = useState(0);
   const [recentTransactions, setRecentTransactions] = useState([]);
   const [userProfile, setUserProfile] = useState(null);

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/ReportsPage.jsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
 import { Container, Row, Col, Card, Form, Button } from "react-bootstrap";
 import {
@@ -16,6 +16,7 @@ import {
   Legend,
 } from "recharts";
 import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
 
 const COLORS = [
   "#0088FE",
@@ -32,7 +33,8 @@ const COLORS = [
   "#2ECC71",
 ];
 
-const ReportsPage = ({ token }) => {
+const ReportsPage = () => {
+  const { token } = useContext(AuthContext);
   const [reportType, setReportType] = useState("monthly");
   const [selectedMonth, setSelectedMonth] = useState(
     new Date().toISOString().slice(0, 7)

--- a/frontend/src/pages/SavingGoalsPage.jsx
+++ b/frontend/src/pages/SavingGoalsPage.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/SavingGoalsPage.jsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
 import {
   Container,
@@ -13,8 +13,10 @@ import {
 } from "react-bootstrap";
 import { FaEdit, FaTrashAlt } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
 
-const SavingGoalsPage = ({ token }) => {
+const SavingGoalsPage = () => {
+  const { token } = useContext(AuthContext);
   const [goals, setGoals] = useState([]);
   const [newGoalName, setNewGoalName] = useState("");
   const [newGoalTargetAmount, setNewGoalTargetAmount] = useState("");

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,10 +1,12 @@
 // frontend/src/pages/SettingsPage.jsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
 import { Container, Card, Form, Button, Alert, Image } from "react-bootstrap";
 import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
 
-const SettingsPage = ({ token }) => {
+const SettingsPage = () => {
+  const { token } = useContext(AuthContext);
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmNewPassword, setConfirmNewPassword] = useState("");

--- a/frontend/src/pages/TransactionsPage.jsx
+++ b/frontend/src/pages/TransactionsPage.jsx
@@ -1,11 +1,13 @@
 // frontend/src/pages/TransactionsPage.jsx
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import api from '../services/api';
 import { Container, Row, Col, Form, Button, Card, ListGroup } from 'react-bootstrap';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 import { toast } from 'react-toastify';
+import { AuthContext } from '../context/AuthContext';
 
-const TransactionsPage = ({ token }) => {
+const TransactionsPage = () => {
+  const { token } = useContext(AuthContext);
   const [accounts, setAccounts] = useState([]);
   const [transactions, setTransactions] = useState([]);
   const [categories, setCategories] = useState([]);


### PR DESCRIPTION
## Summary
- provide `AuthContext` with `login` and `logout` helpers
- wrap the app with `AuthProvider`
- use context inside pages and layout instead of prop drilling
- add `ProtectedRoute` component

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499a8da9b4832597457a25c80d6c80