### PR TITLE
Fix commented console.log block in SettingsPage

### DIFF
--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -143,7 +143,7 @@ const SettingsPage = () => {
       // console.log(
 //         "DEBUG: SettingsPage - Respuesta de subida de foto:",
 //         res.data
-      );
+//       );
       toast.success(res.data.msg);
       setProfilePictureFile(null); // Limpiar el input de archivo
       setProfilePicError(""); // Limpiar error


### PR DESCRIPTION
## Summary
- fully comment a dangling `console.log` closing line in `SettingsPage.jsx`

## Testing
- `npm run build` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae488dfc8325aa209024e3c78a3b