### PR TITLE
Remove unused console logs in AccountsPage

### DIFF
--- a/frontend/src/pages/AccountsPage.jsx
+++ b/frontend/src/pages/AccountsPage.jsx
@@ -32,12 +32,7 @@ const AccountsPage = () => {
         toast.error("Token no encontrado. Por favor, inicia sesión de nuevo.");
         return;
       }
-      // console.log("DEBUG: AccountsPage - Enviando GET a /api/accounts...");
       const res = await api.get(`/accounts`);
-      // console.log(
-      //   "DEBUG: AccountsPage - Respuesta de /api/accounts:",
-      //   res.data
-      // );
       if (Array.isArray(res.data)) {
         setAccounts(res.data);
       } else {


### PR DESCRIPTION
## Summary
- tidy up fetchAccounts by removing old debug console.log statements

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae44048883259f14927d4039eb05