### PR TITLE
Organize settings and accounts layouts

### DIFF
--- a/frontend/src/pages/AccountsPage.jsx
+++ b/frontend/src/pages/AccountsPage.jsx
@@ -169,9 +169,11 @@ const AccountsPage = () => {
     <Container className="py-4">
       <h2 className="mb-4 text-center page-title">Gestión de Cuentas</h2>
 
-      {/* Formulario para Añadir/Editar Cuenta */}
-      <Card className="mb-4 shadow-sm">
-        <Card.Body>
+      <Row className="g-4">
+        <Col md={6}>
+          {/* Formulario para Añadir/Editar Cuenta */}
+          <Card className="mb-4 shadow-sm h-100">
+            <Card.Body>
           <Card.Title className="text-center mb-3">
             {editingAccount ? "Editar Cuenta" : "Añadir Nueva Cuenta"}
           </Card.Title>
@@ -325,9 +327,11 @@ const AccountsPage = () => {
         </Card.Body>
       </Card>
 
-      {/* Listado de Cuentas */}
-      <Card className="shadow-sm">
-        <Card.Body>
+        {/* Listado de Cuentas */}
+        </Col>
+        <Col md={6}>
+          <Card className="shadow-sm h-100">
+            <Card.Body>
           <Card.Title className="text-center mb-3">Tus Cuentas</Card.Title>
           {accounts.length === 0 ? (
             <p className="text-center">
@@ -368,6 +372,8 @@ const AccountsPage = () => {
           )}
         </Card.Body>
       </Card>
+        </Col>
+      </Row>
     </Container>
   );
 };

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,7 +1,16 @@
 // frontend/src/pages/SettingsPage.jsx
 import React, { useState, useEffect, useCallback, useContext } from "react";
 import api from "../services/api";
-import { Container, Card, Form, Button, Alert, Image } from "react-bootstrap";
+import {
+  Container,
+  Card,
+  Form,
+  Button,
+  Alert,
+  Image,
+  Tabs,
+  Tab,
+} from "react-bootstrap";
 import { toast } from "react-toastify";
 import { AuthContext } from "../context/AuthContext";
 
@@ -205,15 +214,16 @@ const SettingsPage = () => {
     <Container className="py-4">
       <h2 className="mb-4 text-center page-title">Configuración de Usuario</h2>
 
-      {/* Tarjeta para Cambiar Contraseña */}
-      <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
-        <Card.Body>
-          <Card.Title className="text-center mb-3">
-            Cambiar Contraseña
-          </Card.Title>
-          {formError && <Alert variant="danger">{formError}</Alert>}{" "}
-          {/* Error de contraseña */}
-          <Form onSubmit={handleChangePassword}>
+      <Tabs defaultActiveKey="password" className="mb-4" fill>
+        <Tab eventKey="password" title="Seguridad">
+          <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
+            <Card.Body>
+              <Card.Title className="text-center mb-3">
+                Cambiar Contraseña
+              </Card.Title>
+              {formError && <Alert variant="danger">{formError}</Alert>}{" "}
+              {/* Error de contraseña */}
+              <Form onSubmit={handleChangePassword}>
             <Form.Group className="mb-3" controlId="currentPassword">
               <Form.Label>Contraseña Actual:</Form.Label>
               <Form.Control
@@ -264,11 +274,12 @@ const SettingsPage = () => {
           </Form>
         </Card.Body>
       </Card>
+        </Tab>
 
-      {/* Tarjeta para Subir Foto de Perfil */}
-      <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
-        <Card.Body>
-          <Card.Title className="text-center mb-3">Foto de Perfil</Card.Title>
+        <Tab eventKey="profile" title="Foto de Perfil">
+          <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
+            <Card.Body>
+              <Card.Title className="text-center mb-3">Foto de Perfil</Card.Title>
           <div className="text-center mb-3">
             {userProfile?.profilePictureUrl ? (
               <Image
@@ -323,13 +334,14 @@ const SettingsPage = () => {
           </Form>
         </Card.Body>
       </Card>
+        </Tab>
 
-      {/* Tarjeta para Subir Banner */}
-      <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
-        <Card.Body>
-          <Card.Title className="text-center mb-3">
-            Banner del Perfil
-          </Card.Title>
+        <Tab eventKey="banner" title="Banner">
+          <Card className="shadow-sm mx-auto mb-4" style={{ maxWidth: "500px" }}>
+            <Card.Body>
+              <Card.Title className="text-center mb-3">
+                Banner del Perfil
+              </Card.Title>
           <div className="text-center mb-3">
             {userProfile?.bannerUrl ? (
               <Image
@@ -379,6 +391,8 @@ const SettingsPage = () => {
           </Form>
         </Card.Body>
       </Card>
+        </Tab>
+      </Tabs>
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- organize settings page sections using tabs
- arrange accounts form and list side-by-side

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd7d5b288325b87cfdbc8af93be2