### PR TITLE
Add subscriptions management feature

### DIFF
--- a/backend/controllers/subscriptionController.js
+++ b/backend/controllers/subscriptionController.js
@@ -1,0 +1,81 @@
+// backend/controllers/subscriptionController.js
+const Subscription = require("../models/Subscription");
+
+// Obtener todas las suscripciones del usuario
+exports.getSubscriptions = async (req, res) => {
+  try {
+    const subs = await Subscription.find({ user: req.user.id }).sort({ nextBillingDate: 1 });
+    res.json(subs);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send("Error del servidor");
+  }
+};
+
+// Crear nueva suscripción
+exports.createSubscription = async (req, res) => {
+  const { name, amount, nextBillingDate, frequency, notes } = req.body;
+
+  try {
+    const sub = new Subscription({
+      user: req.user.id,
+      name,
+      amount: parseFloat(amount),
+      nextBillingDate,
+      frequency,
+      notes,
+    });
+
+    const saved = await sub.save();
+    res.status(201).json(saved);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send("Error del servidor");
+  }
+};
+
+// Actualizar suscripción
+exports.updateSubscription = async (req, res) => {
+  const { name, amount, nextBillingDate, frequency, notes } = req.body;
+
+  try {
+    let sub = await Subscription.findById(req.params.id);
+    if (!sub) {
+      return res.status(404).json({ msg: "Suscripción no encontrada" });
+    }
+
+    if (sub.user.toString() !== req.user.id) {
+      return res.status(401).json({ msg: "No autorizado" });
+    }
+
+    sub.name = name || sub.name;
+    sub.amount = amount !== undefined ? parseFloat(amount) : sub.amount;
+    sub.nextBillingDate = nextBillingDate || sub.nextBillingDate;
+    sub.frequency = frequency || sub.frequency;
+    sub.notes = notes !== undefined ? notes : sub.notes;
+
+    await sub.save();
+    res.json(sub);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send("Error del servidor");
+  }
+};
+
+// Eliminar suscripción
+exports.deleteSubscription = async (req, res) => {
+  try {
+    const sub = await Subscription.findById(req.params.id);
+    if (!sub) {
+      return res.status(404).json({ msg: "Suscripción no encontrada" });
+    }
+    if (sub.user.toString() !== req.user.id) {
+      return res.status(401).json({ msg: "No autorizado" });
+    }
+    await Subscription.deleteOne({ _id: req.params.id });
+    res.json({ msg: "Suscripción eliminada" });
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send("Error del servidor");
+  }
+};

--- a/backend/models/Subscription.js
+++ b/backend/models/Subscription.js
@@ -1,0 +1,16 @@
+// backend/models/Subscription.js
+const mongoose = require("mongoose");
+
+const SubscriptionSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    name: { type: String, required: true },
+    amount: { type: Number, required: true },
+    nextBillingDate: { type: Date, required: true },
+    frequency: { type: String, default: "Mensual" },
+    notes: String,
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Subscription", SubscriptionSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -27,14 +27,16 @@ const UserSchema = new Schema({
     required: false,
   },
   profilePictureUrl: {
-    // <-- NUEVO: URL de la foto de perfil
     type: String,
     required: false,
+    default:
+      "https://via.placeholder.com/100/ecf0f1/2c3e50?text=Perfil", // Imagen por defecto
   },
   bannerUrl: {
-    // <-- NUEVO: URL del banner
     type: String,
     required: false,
+    default:
+      "https://via.placeholder.com/800x150/3498db/ffffff?text=Banner", // Imagen por defecto
   },
   date: {
     type: Date,

--- a/backend/routes/subscription.js
+++ b/backend/routes/subscription.js
@@ -1,0 +1,12 @@
+// backend/routes/subscription.js
+const express = require("express");
+const router = express.Router();
+const auth = require("../middleware/auth");
+const controller = require("../controllers/subscriptionController");
+
+router.get("/", auth, controller.getSubscriptions);
+router.post("/", auth, controller.createSubscription);
+router.put("/:id", auth, controller.updateSubscription);
+router.delete("/:id", auth, controller.deleteSubscription);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -46,6 +46,7 @@ app.use("/api/accounts", require("./routes/account"));
 app.use("/api/transactions", require("./routes/transaction"));
 app.use("/api/categories", require("./routes/category"));
 app.use("/api/savinggoals", require("./routes/savingGoal"));
+app.use("/api/subscriptions", require("./routes/subscription"));
 
 app.get("/", (req, res) => {
   res.send("API de Mi Dinero Hoy funcionando!");

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,6 +18,7 @@ import AccountsPage from "./pages/AccountsPage";
 import TransactionsPage from "./pages/TransactionsPage";
 import CategoriesPage from "./pages/CategoriesPage";
 import SavingGoalsPage from "./pages/SavingGoalsPage";
+import SubscriptionsPage from "./pages/SubscriptionsPage";
 import BudgetCalculatorPage from "./pages/BudgetCalculatorPage";
 import ReportsPage from "./pages/ReportsPage";
 import SettingsPage from "./pages/SettingsPage";
@@ -155,6 +156,7 @@ function App() {
               <ProtectedRoute path="/transactions" component={TransactionsPage} />
               <ProtectedRoute path="/categories" component={CategoriesPage} />
               <ProtectedRoute path="/saving-goals" component={SavingGoalsPage} />
+              <ProtectedRoute path="/subscriptions" component={SubscriptionsPage} />
               <Route
                 path="/budget-calculator"
                 component={BudgetCalculatorPage}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -10,6 +10,7 @@ import {
   FaBullseye,
   FaCog,
   FaCalculator,
+  FaBell,
   FaSignOutAlt,
   FaSignInAlt,
   FaUserPlus,
@@ -51,6 +52,7 @@ const Layout = ({ children }) => {
       icon: <FaCalculator />,
     },
     { name: "Metas de Ahorro", path: "/saving-goals", icon: <FaBullseye /> },
+    { name: "Suscripciones", path: "/subscriptions", icon: <FaBell /> },
     { name: "Educación Financiera", path: "/educate", icon: <FaBookOpen /> },
     { name: "Configuración", path: "/settings", icon: <FaCog /> },
     // { name: "Ayuda y FAQ", path: "/help", icon: <FaQuestionCircle /> }, // Comentado si no tienes la página

--- a/frontend/src/pages/SubscriptionsPage.jsx
+++ b/frontend/src/pages/SubscriptionsPage.jsx
@@ -1,0 +1,284 @@
+// frontend/src/pages/SubscriptionsPage.jsx
+import React, { useState, useEffect, useCallback, useContext } from "react";
+import api from "../services/api";
+import {
+  Container,
+  Row,
+  Col,
+  Form,
+  Button,
+  Card,
+  ListGroup,
+} from "react-bootstrap";
+import { FaEdit, FaTrashAlt, FaBell } from "react-icons/fa";
+import { toast } from "react-toastify";
+import { AuthContext } from "../context/AuthContext";
+
+const SubscriptionsPage = () => {
+  const { token } = useContext(AuthContext);
+  const [subs, setSubs] = useState([]);
+  const [newName, setNewName] = useState("");
+  const [newAmount, setNewAmount] = useState("");
+  const [newDate, setNewDate] = useState("");
+  const [newFrequency, setNewFrequency] = useState("Mensual");
+  const [editing, setEditing] = useState(null);
+  const [formErrors, setFormErrors] = useState({});
+
+  const fetchSubs = useCallback(async () => {
+    try {
+      if (!token) return;
+      const res = await api.get(`/subscriptions`);
+      if (Array.isArray(res.data)) setSubs(res.data);
+      else {
+        setSubs([]);
+        toast.error("Formato de datos de suscripciones inesperado.");
+      }
+    } catch (err) {
+      toast.error(
+        `Error al cargar suscripciones: ${err.response?.data?.msg || err.message}`
+      );
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchSubs();
+  }, [fetchSubs]);
+
+  useEffect(() => {
+    const today = new Date();
+    subs.forEach((s) => {
+      const date = new Date(s.nextBillingDate);
+      const diff = (date - today) / (1000 * 60 * 60 * 24);
+      if (diff >= 0 && diff <= 3) {
+        toast.info(
+          `La suscripción "${s.name}" se cobrará pronto (${date.toLocaleDateString()}).`,
+          { icon: <FaBell /> }
+        );
+      }
+    });
+  }, [subs]);
+
+  const validateForm = (data) => {
+    const errors = {};
+    if (!data.name) errors.name = "El nombre es requerido";
+    if (isNaN(parseFloat(data.amount)) || parseFloat(data.amount) <= 0)
+      errors.amount = "Monto inválido";
+    if (!data.nextBillingDate) errors.nextBillingDate = "Fecha requerida";
+    setFormErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleAdd = async (e) => {
+    e.preventDefault();
+    const data = {
+      name: newName,
+      amount: newAmount,
+      nextBillingDate: newDate,
+      frequency: newFrequency,
+    };
+    if (!validateForm(data)) return;
+    try {
+      await api.post(`/subscriptions`, data);
+      toast.success("Suscripción creada");
+      setNewName("");
+      setNewAmount("");
+      setNewDate("");
+      setNewFrequency("Mensual");
+      setFormErrors({});
+      fetchSubs();
+    } catch (err) {
+      toast.error(
+        `Error al crear suscripción: ${err.response?.data?.msg || err.message}`
+      );
+    }
+  };
+
+  const startEdit = (sub) => {
+    setEditing({
+      ...sub,
+      nextBillingDate: sub.nextBillingDate
+        ? new Date(sub.nextBillingDate).toISOString().slice(0, 10)
+        : "",
+    });
+    setFormErrors({});
+  };
+
+  const cancelEdit = () => {
+    setEditing(null);
+    setFormErrors({});
+  };
+
+  const handleUpdate = async (e) => {
+    e.preventDefault();
+    if (!editing) return;
+    if (!validateForm(editing)) return;
+    try {
+      await api.put(`/subscriptions/${editing._id}`, editing);
+      toast.success("Suscripción actualizada");
+      setEditing(null);
+      fetchSubs();
+    } catch (err) {
+      toast.error(
+        `Error al actualizar: ${err.response?.data?.msg || err.message}`
+      );
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (window.confirm("¿Eliminar suscripción?")) {
+      try {
+        await api.delete(`/subscriptions/${id}`);
+        toast.success("Suscripción eliminada");
+        fetchSubs();
+      } catch (err) {
+        toast.error(
+          `Error al eliminar: ${err.response?.data?.msg || err.message}`
+        );
+      }
+    }
+  };
+
+  const handleChangeEditing = (field, value) => {
+    setEditing({ ...editing, [field]: value });
+  };
+
+  return (
+    <Container className="py-4">
+      <h2 className="mb-4 text-center page-title">Suscripciones</h2>
+      <Row>
+        <Col md={5} lg={4}>
+          <Card className="shadow-sm mb-4">
+            <Card.Body>
+              <Card.Title className="mb-3 text-center">
+                {editing ? "Editar Suscripción" : "Nueva Suscripción"}
+              </Card.Title>
+              <Form onSubmit={editing ? handleUpdate : handleAdd}>
+                <Form.Group className="mb-3" controlId="name">
+                  <Form.Label>Nombre</Form.Label>
+                  <Form.Control
+                    type="text"
+                    value={editing ? editing.name : newName}
+                    onChange={(e) =>
+                      editing
+                        ? handleChangeEditing("name", e.target.value)
+                        : setNewName(e.target.value)
+                    }
+                    isInvalid={!!formErrors.name}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {formErrors.name}
+                  </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group className="mb-3" controlId="amount">
+                  <Form.Label>Monto</Form.Label>
+                  <Form.Control
+                    type="number"
+                    value={editing ? editing.amount : newAmount}
+                    onChange={(e) =>
+                      editing
+                        ? handleChangeEditing("amount", e.target.value)
+                        : setNewAmount(e.target.value)
+                    }
+                    isInvalid={!!formErrors.amount}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {formErrors.amount}
+                  </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group className="mb-3" controlId="nextBillingDate">
+                  <Form.Label>Próximo cobro</Form.Label>
+                  <Form.Control
+                    type="date"
+                    value={editing ? editing.nextBillingDate : newDate}
+                    onChange={(e) =>
+                      editing
+                        ? handleChangeEditing("nextBillingDate", e.target.value)
+                        : setNewDate(e.target.value)
+                    }
+                    isInvalid={!!formErrors.nextBillingDate}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {formErrors.nextBillingDate}
+                  </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group className="mb-3" controlId="frequency">
+                  <Form.Label>Frecuencia</Form.Label>
+                  <Form.Control
+                    as="select"
+                    value={editing ? editing.frequency : newFrequency}
+                    onChange={(e) =>
+                      editing
+                        ? handleChangeEditing("frequency", e.target.value)
+                        : setNewFrequency(e.target.value)
+                    }
+                  >
+                    <option>Mensual</option>
+                    <option>Anual</option>
+                  </Form.Control>
+                </Form.Group>
+                <div className="d-grid gap-2">
+                  <Button variant="primary" type="submit" className="fancy-btn">
+                    {editing ? "Actualizar" : "Agregar"}
+                  </Button>
+                  {editing && (
+                    <Button variant="secondary" onClick={cancelEdit}>
+                      Cancelar
+                    </Button>
+                  )}
+                </div>
+              </Form>
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col md={7} lg={8}>
+          <Card className="shadow-sm">
+            <Card.Body>
+              <Card.Title className="mb-3 text-center">
+                Tus Suscripciones
+              </Card.Title>
+              {subs.length === 0 ? (
+                <p className="text-center text-muted">Sin suscripciones.</p>
+              ) : (
+                <ListGroup variant="flush">
+                  {subs.map((s) => (
+                    <ListGroup.Item
+                      key={s._id}
+                      className="d-flex justify-content-between align-items-center"
+                    >
+                      <div>
+                        <strong>{s.name}</strong>
+                        <div className="text-muted" style={{ fontSize: "0.85em" }}>
+                          {new Date(s.nextBillingDate).toLocaleDateString()} - $
+                          {s.amount.toFixed(2)} ({s.frequency})
+                        </div>
+                      </div>
+                      <div>
+                        <Button
+                          variant="outline-primary"
+                          size="sm"
+                          className="me-2"
+                          onClick={() => startEdit(s)}
+                        >
+                          <FaEdit />
+                        </Button>
+                        <Button
+                          variant="outline-danger"
+                          size="sm"
+                          onClick={() => handleDelete(s._id)}
+                        >
+                          <FaTrashAlt />
+                        </Button>
+                      </div>
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default SubscriptionsPage;


### PR DESCRIPTION
## Summary
- set default profile and banner placeholder URLs in the User model
- create Subscription model, controller and routes
- expose subscriptions routes in the backend server
- add Subscriptions page to frontend and link in navigation
- wire new page into app routing

## Testing
- `npm test --silent` in `frontend` *(fails: `react-scripts` not found)*
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6849d072b8f08325bfaf707125ee675a