### PR TITLE
Fix stray main invocation in server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -49,7 +49,6 @@ app.use("/api/savinggoals", require("./routes/savingGoal"));
 app.use("/api/subscriptions", require("./routes/subscription"));
 app.use("/api/currency", require("./routes/currency"));
 app.use("/api/reminders", require("./routes/reminder"));
- main
 
 app.get("/", (req, res) => {
   res.send("API de Mi Dinero Hoy funcionando!");


### PR DESCRIPTION
## Summary
- remove leftover `main` line in server.js

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684aac54b3ac8325b006467e345dee91