### PR TITLE
Add mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aplicación full-stack para gestión de finanzas personales.
 
 - **backend/**: API REST en Node.js + Express
 - **frontend/**: SPA con React
+- **mobile/**: app móvil con React Native (Expo)
 
 ## Variables de entorno
 
@@ -37,6 +38,7 @@ URLs duplicadas al construir las rutas.
 - `npm run dev`: corre frontend y backend en desarrollo (concurrently)
 - `npm run start`: inicia la aplicación en producción
 - `npm run start-frontend`: usa `cross-env` para configurar variables de entorno antes de ejecutar React
+- `npm run start-mobile`: inicia la app móvil con Expo
 
 ## Despliegue
 

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SafeAreaView, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Mi Dinero Hoy</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold'
+  }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,13 @@
+# App móvil
+
+Esta carpeta contiene una versión mínima en React Native (Expo) de **Mi Dinero Hoy**.
+
+## Scripts disponibles
+
+- `npm start`: inicia el servidor de desarrollo de Expo.
+- `npm run android`: compila y ejecuta en Android.
+- `npm run ios`: compila y ejecuta en iOS.
+
+## Requisitos
+
+Necesitas tener instalado [Expo CLI](https://docs.expo.dev/workflow/expo-cli/) y las herramientas de desarrollo de React Native.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "MiDineroHoy",
+    "slug": "mi-dinero-hoy-mobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android"],
+    "sdkVersion": "50.0.0"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "~50.0.0",
+    "react": "18.3.1",
+    "react-native": "0.73.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start-backend": "cd backend && node server.js",
     "start-frontend": "cd frontend && cross-env NODE_OPTIONS=--openssl-legacy-provider CHOKIDAR_USEPOLLING=true npm start",
-    "dev": "concurrently \"npm run start-backend\" \"npm run start-frontend\""
+    "dev": "concurrently \"npm run start-backend\" \"npm run start-frontend\"",
+    "start-mobile": "cd mobile && expo start"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add new `mobile/` folder with React Native (Expo) setup
- expose `start-mobile` npm script
- document mobile app and new script in README

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: no test specified)*
- `cd frontend && npm test` *(fails: react-scripts not found)*
- `cd mobile && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684abf8e85b8832581ce4bbaa081bbd3